### PR TITLE
feat: add refactored n8n workflows

### DIFF
--- a/n8n/chat_ia_refactored.json
+++ b/n8n/chat_ia_refactored.json
@@ -1,0 +1,161 @@
+{
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "ventas-chat",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-ventas-chat",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [-1020, 0],
+      "webhookId": "ventas-chat"
+    },
+    {
+      "parameters": {
+        "keepOnlySet": true,
+        "values": {
+          "string": [
+            {"name": "prompt", "value": "={{ $json.body.prompt || $json.body.message }}"}
+          ]
+        }
+      },
+      "id": "normalize-input",
+      "name": "Normalize Input",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [-800, 0]
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.VAPERS_API_BASE + '/ventas' }}",
+        "responseFormat": "json",
+        "options": {
+          "retryOnFail": true,
+          "maxRetries": 3
+        }
+      },
+      "id": "fetch-sales",
+      "name": "Fetch Sales",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [-600, 120]
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.VAPERS_API_BASE + '/vapers' }}",
+        "responseFormat": "json",
+        "options": {
+          "retryOnFail": true,
+          "maxRetries": 3
+        }
+      },
+      "id": "fetch-vapers",
+      "name": "Fetch Inventory",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [-600, -120]
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.VAPERS_API_BASE + '/finanzas' }}",
+        "responseFormat": "json",
+        "options": {
+          "retryOnFail": true,
+          "maxRetries": 3
+        }
+      },
+      "id": "fetch-finanzas",
+      "name": "Fetch Finance",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [-600, -240]
+    },
+    {
+      "parameters": {
+        "functionCode": "const prompt = $json.prompt;\nconst ventas = $items('Fetch Sales')[0].json || [];\nconst vapers = $items('Fetch Inventory')[0].json || [];\nconst finanzas = $items('Fetch Finance')[0].json || [];\n\nreturn [{ json: { prompt, ventas, vapers, finanzas } }];"
+      },
+      "id": "aggregate-context",
+      "name": "Aggregate Context",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [-360, 0]
+    },
+    {
+      "parameters": {
+        "functionCode": "const text = ($json.prompt || '').toLowerCase();\nlet intent = 'ventas';\nif (/(inventario|stock|producto|vaper)/.test(text)) intent = 'vapers';\nif (/(finanza|gasto|beneficio)/.test(text)) intent = 'finanzas';\nreturn [{ json: { ...$json, intent } }];"
+      },
+      "id": "detect-intent",
+      "name": "Detect Intent",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [-120, 0]
+    },
+    {
+      "parameters": {
+        "functionCode": "const {prompt, intent, ventas, vapers, finanzas} = $json;\nconst ctx = { ventas, vapers, finanzas };\nconst sistema = 'Eres un asistente que responde en español usando solo el contexto proporcionado';\nreturn [{ json: { model: 'llama-3.3-70b-versatile', messages: [ {role: 'system', content: sistema}, {role: 'user', content: prompt}, {role: 'user', content: `CONTEXTO ${intent.toUpperCase()}: ${JSON.stringify(ctx[intent]||{})}`} ] } }];"
+      },
+      "id": "build-messages",
+      "name": "Build Messages",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [120, 0]
+    },
+    {
+      "parameters": {
+        "requestMethod": "POST",
+        "url": "https://api.groq.com/openai/v1/chat/completions",
+        "jsonParameters": true,
+        "options": {
+          "retryOnFail": true,
+          "maxRetries": 2
+        },
+        "bodyParametersJson": "={{ { model: $json.model, messages: $json.messages, temperature: 0.2, max_tokens: 900 } }}",
+        "headerParametersJson": "={{ { 'Authorization': 'Bearer ' + $env.GROQ_API_KEY, 'Content-Type': 'application/json' } }}"
+      },
+      "id": "groq-chat",
+      "name": "Groq Chat",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [360, 0]
+    },
+    {
+      "parameters": {
+        "functionCode": "const r = $json; const content = r.choices?.[0]?.message?.content || 'Sin respuesta'; return [{ json: { answer: content } }];"
+      },
+      "id": "extract-answer",
+      "name": "Extract Answer",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [600, 0]
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "id": "respond",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [840, 0]
+    }
+  ],
+  "connections": {
+    "Webhook": { "main": [[ { "node": "Normalize Input", "type": "main", "index": 0 } ]] },
+    "Normalize Input": { "main": [[ { "node": "Fetch Sales", "type": "main", "index": 0 }, { "node": "Fetch Inventory", "type": "main", "index": 0 }, { "node": "Fetch Finance", "type": "main", "index": 0 } ]] },
+    "Fetch Sales": { "main": [[ { "node": "Aggregate Context", "type": "main", "index": 0 } ]] },
+    "Fetch Inventory": { "main": [[ { "node": "Aggregate Context", "type": "main", "index": 0 } ]] },
+    "Fetch Finance": { "main": [[ { "node": "Aggregate Context", "type": "main", "index": 0 } ]] },
+    "Aggregate Context": { "main": [[ { "node": "Detect Intent", "type": "main", "index": 0 } ]] },
+    "Detect Intent": { "main": [[ { "node": "Build Messages", "type": "main", "index": 0 } ]] },
+    "Build Messages": { "main": [[ { "node": "Groq Chat", "type": "main", "index": 0 } ]] },
+    "Groq Chat": { "main": [[ { "node": "Extract Answer", "type": "main", "index": 0 } ]] },
+    "Extract Answer": { "main": [[ { "node": "Respond", "type": "main", "index": 0 } ]] }
+  },
+  "meta": {
+    "instanceId": "workflow-refactor"
+  }
+}

--- a/n8n/daily_sales_digest.json
+++ b/n8n/daily_sales_digest.json
@@ -1,0 +1,91 @@
+{
+  "nodes": [
+    {
+      "parameters": {
+        "triggerTimes": [{
+          "item": {
+            "mode": "everyDay",
+            "hour": 7
+          }
+        }]
+      },
+      "id": "cron",
+      "name": "Daily 7AM",
+      "type": "n8n-nodes-base.cron",
+      "typeVersion": 1,
+      "position": [-960, 0]
+    },
+    {
+      "parameters": {
+        "functionCode": "const now = new Date();\nconst end = new Date(now.getFullYear(), now.getMonth(), now.getDate());\nconst start = new Date(end.getTime() - 24*60*60*1000);\nreturn [{ json: { from: start.toISOString(), to: end.toISOString() } }];"
+      },
+      "id": "set-period",
+      "name": "Set Period",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [-720, 0]
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.VAPERS_API_BASE + '/ventas' }}",
+        "responseFormat": "json",
+        "options": {
+          "retryOnFail": true,
+          "maxRetries": 3
+        }
+      },
+      "id": "fetch-sales",
+      "name": "Fetch Sales",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [-480, 0]
+    },
+    {
+      "parameters": {
+        "functionCode": "const period = $items('Set Period')[0].json;\nconst ventas = $json || [];\nconst desde = new Date(period.from);\nconst hasta = new Date(period.to);\nconst filtradas = ventas.filter(v => { const d = new Date(v.fecha); return d >= desde && d < hasta; });\nconst total = filtradas.reduce((a,v) => a + Number(v.total || 0), 0);\nreturn [{ json: { from: period.from, to: period.to, total, count: filtradas.length } }];"
+      },
+      "id": "compute-digest",
+      "name": "Compute Digest",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [-240, 0]
+    },
+    {
+      "parameters": {
+        "functionCode": "const {from,to,total,count} = $json;\nconst text = `Ventas del ${from} al ${to}:\\nIngresos: $${total}\\nNúmero de ventas: ${count}`;\nreturn [{ json: { text } }];"
+      },
+      "id": "build-message",
+      "name": "Build Message",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "resource": "message",
+        "operation": "post",
+        "channel": "={{ $env.SLACK_CHANNEL_SALES }}",
+        "text": "={{ $json.text }}"
+      },
+      "id": "send-slack",
+      "name": "Send Slack",
+      "type": "n8n-nodes-base.slack",
+      "typeVersion": 1,
+      "position": [240, 0],
+      "credentials": {
+        "slackApi": {
+          "id": "={{ $env.SLACK_CRED_ID }}",
+          "name": "Slack Account"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Daily 7AM": {"main": [[{"node": "Set Period", "type": "main", "index": 0}]]},
+    "Set Period": {"main": [[{"node": "Fetch Sales", "type": "main", "index": 0}, {"node": "Compute Digest", "type": "main", "index": 0}]]},
+    "Fetch Sales": {"main": [[{"node": "Compute Digest", "type": "main", "index": 0}]]},
+    "Compute Digest": {"main": [[{"node": "Build Message", "type": "main", "index": 0}]]},
+    "Build Message": {"main": [[{"node": "Send Slack", "type": "main", "index": 0}]]}
+  },
+  "meta": {"instanceId": "workflow-daily-sales"}
+}

--- a/n8n/inventory_low_stock_alert.json
+++ b/n8n/inventory_low_stock_alert.json
@@ -1,0 +1,108 @@
+{
+  "nodes": [
+    {
+      "parameters": {
+        "triggerTimes": [{
+          "item": {
+            "mode": "everyDay",
+            "hour": 8
+          }
+        }]
+      },
+      "id": "cron",
+      "name": "Daily 8AM",
+      "type": "n8n-nodes-base.cron",
+      "typeVersion": 1,
+      "position": [-960, 0]
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.VAPERS_API_BASE + '/vapers' }}",
+        "responseFormat": "json",
+        "options": {
+          "retryOnFail": true,
+          "maxRetries": 3
+        }
+      },
+      "id": "fetch-inventory",
+      "name": "Fetch Inventory",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [-720, 0]
+    },
+    {
+      "parameters": {
+        "functionCode": "const threshold = Number($env.LOW_STOCK_THRESHOLD || 5);\nconst low = ($json || []).filter(i => Number(i.stock) <= threshold);\nreturn [{ json: { lowStock: low, threshold } }];"
+      },
+      "id": "filter-low-stock",
+      "name": "Filter Low Stock",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [-480, 0]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "number": [
+            {"value1": "={{ $json.lowStock.length }}", "operation": "greater", "value2": 0}
+          ]
+        }
+      },
+      "id": "has-low-stock",
+      "name": "Has Low Stock?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [-240, 0]
+    },
+    {
+      "parameters": {
+        "functionCode": "const items = $json.lowStock;\nconst lines = items.map(i => `• ${i.nombre} (stock: ${i.stock})`);\nconst text = `Productos con stock bajo (≤ ${$json.threshold}):\n` + lines.join('\n');\nreturn [{ json: { text } }];"
+      },
+      "id": "build-message",
+      "name": "Build Message",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "resource": "message",
+        "operation": "post",
+        "channel": "={{ $env.SLACK_CHANNEL_STOCK }}",
+        "text": "={{ $json.text }}"
+      },
+      "id": "send-slack",
+      "name": "Send Slack",
+      "type": "n8n-nodes-base.slack",
+      "typeVersion": 1,
+      "position": [240, 0],
+      "credentials": {
+        "slackApi": {
+          "id": "={{ $env.SLACK_CRED_ID }}",
+          "name": "Slack Account"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Daily 8AM": {
+      "main": [[{"node": "Fetch Inventory", "type": "main", "index": 0}]]
+    },
+    "Fetch Inventory": {
+      "main": [[{"node": "Filter Low Stock", "type": "main", "index": 0}]]
+    },
+    "Filter Low Stock": {
+      "main": [[{"node": "Has Low Stock?", "type": "main", "index": 0}]]
+    },
+    "Has Low Stock?": {
+      "main": [
+        [{"node": "Build Message", "type": "main", "index": 0}],
+        []
+      ]
+    },
+    "Build Message": {
+      "main": [[{"node": "Send Slack", "type": "main", "index": 0}]]
+    }
+  },
+  "meta": {"instanceId": "workflow-inventory-alert"}
+}

--- a/n8n/resumen_ventas_refactored.json
+++ b/n8n/resumen_ventas_refactored.json
@@ -1,0 +1,111 @@
+{
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "resumen-7dias-email",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-resumen",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [-720, 0],
+      "webhookId": "resumen-7dias-email"
+    },
+    {
+      "parameters": {
+        "keepOnlySet": true,
+        "values": {
+          "string": [
+            {"name": "toEmail", "value": "={{ $json.body.toEmail || $env.DEFAULT_REPORT_EMAIL }}"},
+            {"name": "subject", "value": "={{ $json.body.subject || 'Resumen ventas últimos 7 días' }}"}
+          ],
+          "dateTime": [
+            {"name": "from", "value": "={{ new Date(Date.now()-7*24*60*60*1000).toISOString() }}"},
+            {"name": "to", "value": "={{ new Date().toISOString() }}"}
+          ]
+        }
+      },
+      "id": "set-params",
+      "name": "Set Params",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [-480, 0]
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.VAPERS_API_BASE + '/ventas' }}",
+        "responseFormat": "json",
+        "options": {
+          "retryOnFail": true,
+          "maxRetries": 3
+        }
+      },
+      "id": "fetch-ventas",
+      "name": "Fetch Sales",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [-240, 0]
+    },
+    {
+      "parameters": {
+        "functionCode": "const {from,to,toEmail,subject} = $json;\nconst ventas = $items('Fetch Sales')[0].json || [];\nconst desde = new Date(from);\nconst hasta = new Date(to);\nconst filtradas = ventas.filter(v => {const d=new Date(v.fecha);return d>=desde && d<=hasta;});\nconst ingresoTotal = filtradas.reduce((a,v)=> a + Number(v.total||0),0);\nconst unidades = filtradas.reduce((a,v)=> a + Number(v.cantidad||1),0);\nreturn [{ json: {toEmail,subject,periodo:{from, to}, resumen:{ingresoTotal, unidades, numVentas: filtradas.length} } }];"
+      },
+      "id": "calcular-resumen",
+      "name": "Calculate Summary",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "functionCode": "const r = $json;\nconst body = `<h1>Resumen de ventas</h1><p>Periodo: ${r.periodo.from} - ${r.periodo.to}</p><ul><li>Ingresos: ${r.resumen.ingresoTotal}</li><li>Unidades: ${r.resumen.unidades}</li><li>Nº Ventas: ${r.resumen.numVentas}</li></ul>`;\nreturn [{ json: { toEmail: r.toEmail, subject: r.subject, html: body } }];"
+      },
+      "id": "construir-html",
+      "name": "Build HTML",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [240, 0]
+    },
+    {
+      "parameters": {
+        "fromEmail": "reports@example.com",
+        "toEmail": "={{ $json.toEmail }}",
+        "subject": "={{ $json.subject }}",
+        "html": "={{ $json.html }}",
+        "options": {}
+      },
+      "id": "send-email",
+      "name": "Send Email",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 1,
+      "position": [480, 0],
+      "credentials": {
+        "smtp": {"id": "={{ $env.SMTP_CRED_ID }}", "name": "SMTP"}
+      }
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "id": "responder",
+      "name": "Responder",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [720, 0]
+    }
+  ],
+  "connections": {
+    "Webhook": {"main": [[{"node": "Set Params", "type": "main", "index": 0}]]},
+    "Set Params": {"main": [[{"node": "Fetch Sales", "type": "main", "index": 0}]]},
+    "Fetch Sales": {"main": [[{"node": "Calculate Summary", "type": "main", "index": 0}]]},
+    "Calculate Summary": {"main": [[{"node": "Build HTML", "type": "main", "index": 0}]]},
+    "Build HTML": {"main": [[{"node": "Send Email", "type": "main", "index": 0}]]},
+    "Send Email": {"main": [[{"node": "Responder", "type": "main", "index": 0}]]}
+  },
+  "meta": {
+    "instanceId": "workflow-refactor"
+  }
+}


### PR DESCRIPTION
## Summary
- add refactored chat workflow using env vars and retry logic
- add refactored weekly sales email workflow
- add daily inventory alert workflow that posts low-stock items to Slack
- add daily sales digest workflow that summarizes yesterday's revenue on Slack

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7dfe13c08832183fc46992b35a24c